### PR TITLE
Update 0.12.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,6 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ about:
   home: https://seaborn.pydata.org
   license: BSD 3-Clause
   license_family: BSD
-  license_file: LICENSE
+  license_file: LICENSE.md
   summary: Statistical data visualization
   description: |
     Seaborn is a Python visualization library based on matplotlib. It

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,8 @@ requirements:
   run:
     - python
     - numpy >=1.17
+    # matplotlib 3.6.1 incompatible with latest master for 0.12.0
+    # https://github.com/mwaskom/seaborn/issues/3072
     - matplotlib >=3.1,!=3.6.1
     - pandas >=0.25
     - typing_extensions  # [py<38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [py<37]
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
 
   host:
     - pip
-    - python >=3.7
+    - python
     - setuptools
     - wheel
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "0.12.0" %}
 {% set name = "seaborn" %}
-{% set sha256 = "cf45e9286d40826864be0e3c066f98536982baf701a7caa386511792d61ff4f6" %}
+{% set sha256 = "893f17292d8baca616c1578ddb58eb25c72d622f54fc5ee329c8207dc9b57b23" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - matplotlib >=3.1,!=3.6.1
     - scipy >=1.0
     - pandas >=0.25
+    - typing_extensions  # [py<38]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
 
   run:
     - python >=3.7
-    - numpy >=1.15
+    - numpy >=1.17
     - matplotlib >=2.2
     - scipy >=1.0
     - pandas >=0.23

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,9 +52,10 @@ test:
 
 about:
   home: https://seaborn.pydata.org
-  license: BSD 3-Clause
+  license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.md
+  license_url: https://github.com/mwaskom/seaborn/blob/master/LICENSE.md
   summary: Statistical data visualization
   description: |
     Seaborn is a Python visualization library based on matplotlib. It

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,6 @@ test:
     - seaborn
     - seaborn.colors
     - seaborn.external
-    - seaborn.tests
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,9 +29,12 @@ requirements:
     - python >=3.7
     - numpy >=1.17
     - matplotlib >=3.1,!=3.6.1
-    - scipy >=1.0
     - pandas >=0.25
     - typing_extensions  # [py<38]
+
+  run_constrained:
+    - scipy >=1.3
+
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
   run:
     - python >=3.7
     - numpy >=1.17
-    - matplotlib >=2.2
+    - matplotlib >=3.1,!=3.6.1
     - scipy >=1.0
     - pandas >=0.25
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
 
   run_constrained:
     - scipy >=1.3
-
+    - statsmodels >=0.10
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,12 +21,12 @@ requirements:
 
   host:
     - pip
-    - python >=3.6
+    - python >=3.7
     - setuptools
     - wheel
 
   run:
-    - python >=3.6
+    - python >=3.7
     - numpy >=1.15
     - matplotlib >=2.2
     - scipy >=1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - numpy >=1.17
     # matplotlib 3.6.1 incompatible with latest master for 0.12.0
     # https://github.com/mwaskom/seaborn/issues/3072
-    - matplotlib >=3.1,!=3.6.1
+    - matplotlib-base >=3.1,!=3.6.1
     - pandas >=0.25
     - typing_extensions  # [py<38]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - wheel
 
   run:
-    - python >=3.7
+    - python
     - numpy >=1.17
     - matplotlib >=3.1,!=3.6.1
     - pandas >=0.25

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,6 @@ requirements:
   host:
     - pip
     - python
-    - setuptools
-    - wheel
     - flit-core >=3.2,<4
 
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - python
     - setuptools
     - wheel
+    - flit-core >=3.2,<4
 
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - numpy >=1.17
     - matplotlib >=2.2
     - scipy >=1.0
-    - pandas >=0.23
+    - pandas >=0.25
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.11.2" %}
+{% set version = "0.12.0" %}
 {% set name = "seaborn" %}
 {% set sha256 = "cf45e9286d40826864be0e3c066f98536982baf701a7caa386511792d61ff4f6" %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ test:
     - seaborn
     - seaborn.colors
     - seaborn.external
+    - seaborn.objects
   commands:
     - pip check
   requires:


### PR DESCRIPTION
Jira ticket: https://anaconda.atlassian.net/browse/PKG-296
Upstream repo: https://github.com/mwaskom/seaborn

- Updated `seaborn` to 0.12.0
- Added flit-core to host requirements
- Removed `noarch: python` and python version pinnings
- Updated `numpy`, `pandas`, and `matplotlib` versions
- Added typing_extensions for python < 3.8
- Added`run_constrained` for optional dependencies `scipy` and `statsmodels`
- Updated license file, name, and URL
- Removed seaborn.tests, as it no longer exists in the source.