### PR TITLE
Update 0.12.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "0.12.1" %}
+{% set version = "0.12.2" %}
 {% set name = "seaborn" %}
-{% set sha256 = "bb1eb1d51d3097368c187c3ef089c0288ec1fe8aa1c69fb324c68aa1d02df4c1" %}
+{% set sha256 = "374645f36509d0dcab895cba5b47daf0586f77bfe3b36c97c607db7da5be0139" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - wheel
   run:
     - python
-    - numpy >=1.17
+    - numpy >=1.17,!=1.24.0
     # matplotlib 3.6.1 incompatible with latest master for 0.12.0
     # https://github.com/mwaskom/seaborn/issues/3072
     - matplotlib-base >=3.1,!=3.6.1


### PR DESCRIPTION
Jira issue: https://anaconda.atlassian.net/browse/PKG-951
Upstream Repo: https://github.com/mwaskom/seaborn
Changelog: https://github.com/mwaskom/seaborn/releases/tag/v0.12.2

Version bump and added `numpy 1.24.0` incompatibility to match upstream pyproject.toml.